### PR TITLE
chore: added android returnUrls for different browsers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -623,7 +623,7 @@ function generateReturnUrl() {
         return 'android-intent://webview'
     }
 
-    if (isAndroid() && isAndroidMobile()) {
+    if (isAndroid() && isChromeMobile()) {
         return 'android-intent://com.android.chrome'
     }
 
@@ -638,7 +638,7 @@ function isChromeiOS() {
     return /CriOS/.test(navigator.userAgent)
 }
 
-function isAndroidMobile() {
+function isChromeMobile() {
     return /Chrome\/[.0-9]* Mobile/i.test(navigator.userAgent)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -602,6 +602,31 @@ function generateReturnUrl() {
         }
         return rv
     }
+
+    if (isAndroid() && isFirefox()) {
+        return 'android-intent://org.mozilla.firefox'
+    }
+
+    if (isAndroid() && isEdge()) {
+        return 'android-intent://com.microsoft.emmx'
+    }
+
+    if (isAndroid() && isOpera()) {
+        return 'android-intent://com.opera.browser'
+    }
+
+    if (isAndroid() && isBrave()) {
+        return 'android-intent://com.brave.browser'
+    }
+
+    if (isAndroid() && isAndroidWebView()) {
+        return 'android-intent://webview'
+    }
+
+    if (isChromeAndroidMobile()) {
+        return 'android-intent://com.android.chrome'
+    }
+
     return window.location.href
 }
 
@@ -613,6 +638,10 @@ function isChromeiOS() {
     return /CriOS/.test(navigator.userAgent)
 }
 
+function isChromeAndroidMobile() {
+    return /Mobile/.test(navigator.userAgent)
+}
+
 function isFirefox() {
     return /Firefox/i.test(navigator.userAgent)
 }
@@ -621,6 +650,22 @@ function isFirefoxiOS() {
     return /FxiOS/.test(navigator.userAgent)
 }
 
+function isOpera() {
+    return (/OPR/.test(navigator.userAgent) || /Opera/.test(navigator.userAgent))
+}
+
+function isEdge() {
+    return /Edg/.test(navigator.userAgent)
+}
+
 function isBrave() {
     return navigator['brave'] && typeof navigator['brave'].isBrave === 'function'
+}
+
+function isAndroid() {
+    return /Android/.test(navigator.userAgent)
+}
+
+function isAndroidWebView() {
+    return /wv/.test(navigator.userAgent)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -623,7 +623,7 @@ function generateReturnUrl() {
         return 'android-intent://webview'
     }
 
-    if (isChromeAndroidMobile()) {
+    if (isAndroid() && isChromeAndroidMobile()) {
         return 'android-intent://com.android.chrome'
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -623,7 +623,7 @@ function generateReturnUrl() {
         return 'android-intent://webview'
     }
 
-    if (isAndroid() && isChromeAndroidMobile()) {
+    if (isAndroid() && isAndroidMobile()) {
         return 'android-intent://com.android.chrome'
     }
 
@@ -638,8 +638,8 @@ function isChromeiOS() {
     return /CriOS/.test(navigator.userAgent)
 }
 
-function isChromeAndroidMobile() {
-    return /Mobile/.test(navigator.userAgent)
+function isAndroidMobile() {
+    return /Chrome\/[.0-9]* Mobile/i.test(navigator.userAgent)
 }
 
 function isFirefox() {


### PR DESCRIPTION
Specifying the android browser used under `info.return_path` with the format `android-intent://{browserPackageName}` so the android anchor wallet can know which app to open after a transaction.