### PR TITLE
fix: better detection of android webviews

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -851,7 +851,7 @@ function isAndroid() {
 }
 
 function isAndroidWebView() {
-    return /wv/.test(navigator.userAgent)
+    return /wv/.test(navigator.userAgent) || /Android.*AppleWebKit/.test(navigator.userAgent);
 }
 
 function copyToClipboard(text: string) {


### PR DESCRIPTION
It turns out that `wv` isn't always in android webview user agents. The below changes should help a lot though.