### PR TITLE
fix: launch anchor on firefox

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -327,6 +327,7 @@ export default class BrowserTransport implements LinkTransport {
             linkA.addEventListener('click', (event) => {
                 event.preventDefault()
                 iframe.setAttribute('src', sameDeviceUri)
+                window.location.href = sameDeviceUri
             })
         } else {
             linkA.addEventListener('click', (event) => {


### PR DESCRIPTION
Includes the change of the window location when handling the Launch Anchor click in Firefox/Brave